### PR TITLE
C4_W1_Optional_Lab_1: Two small changes for convenience.

### DIFF
--- a/course4/week1-ungraded-labs/C4_W1_Optional_Lab_1_XGBoost_CAIP/C4_W1_Optional_Lab_1.md
+++ b/course4/week1-ungraded-labs/C4_W1_Optional_Lab_1_XGBoost_CAIP/C4_W1_Optional_Lab_1.md
@@ -199,7 +199,7 @@ The following code will create an XGBoost model:
 
 ```
 model = xgb.XGBRegressor(
-    objective='reg:linear'
+    objective='reg:squarederror'
 )
 ```
 
@@ -249,7 +249,7 @@ Let's first define some environment variables that we'll be using throughout the
 ```
 # Update these to your own GCP project, model, and version names
 GCP_PROJECT = '<YOUR_PROJECT_ID>'
-MODEL_BUCKET = '<YOUR_PROJECT_ID>'
+MODEL_BUCKET = 'gs://<YOUR_PROJECT_ID>'
 VERSION_NAME = 'v1'
 MODEL_NAME = 'baby_weight'
 ```


### PR DESCRIPTION
Hi! Here are two small observations when I tried out the code in `C4_W1_Optional_Lab_1.md`:

- The text says the objective function is `objective='reg:squarederror'`, but the code uses `reg:linear`. AFAICT there's no real difference, but `reg:linear` will give a warning and it's a bit confusing.
- For the model buckets I needed to specify the protocol `gs://` otherwise it would assume `file://` I ended up with:

```
proj_id, = !gcloud config list project --format "value(core.project)"
GCP_PROJECT = proj_id
MODEL_BUCKET = f'gs://{proj_id}'
VERSION_NAME = 'v1'
MODEL_NAME = 'baby_weight'
```

What do you think?