### PR TITLE
ReadME updates for VMBox bug

### DIFF
--- a/course4/week2-ungraded-labs/C4_W2_Lab_2_Intro_to_Kubernetes/README.md
+++ b/course4/week2-ungraded-labs/C4_W2_Lab_2_Intro_to_Kubernetes/README.md
@@ -73,6 +73,12 @@ minikube start --mount=True --mount-string="/var/tmp:/var/tmp" --vm-driver=virtu
 Some learners reported the error `StartHost failed, but will try again: creating host: create: creating: Error setting up host only network on machine start: The host-only adapter we just created is not visible. This is a well known VirtualBox bug. You might want to uninstall it and reinstall at least version 5.0.12 that is is supposed to fix this issue` although they had already upgraded or installed VirtualBox 6+. A reboot was required to take effect, message was presented inside `system-preferences -> security & privacy -> general.`
 After the reboot, delete any old VMs with `minikube delete` and rerun the original `minikube start --mount=True --mount-string="/var/tmp:/var/tmp" --vm-driver=virtualbox`.
 
+---
+
+</details>
+</br>
+
+
 For Windows:
 
 ```

--- a/course4/week2-ungraded-labs/C4_W2_Lab_2_Intro_to_Kubernetes/README.md
+++ b/course4/week2-ungraded-labs/C4_W2_Lab_2_Intro_to_Kubernetes/README.md
@@ -67,6 +67,12 @@ For Mac and Linux:
 minikube start --mount=True --mount-string="/var/tmp:/var/tmp" --vm-driver=virtualbox
 ```
 
+<details>
+<summary> <i>Troubleshooting: Please click here if you're getting errors with these commands. </i></summary>
+
+Some learners reported the error `StartHost failed, but will try again: creating host: create: creating: Error setting up host only network on machine start: The host-only adapter we just created is not visible. This is a well known VirtualBox bug. You might want to uninstall it and reinstall at least version 5.0.12 that is is supposed to fix this issue` although they had already upgraded or installed VirtualBox 6+. A reboot was required to take effect, message was presented inside `system-preferences -> security & privacy -> general.`
+After the reboot, delete any old VMs with `minikube delete` and rerun the original `minikube start --mount=True --mount-string="/var/tmp:/var/tmp" --vm-driver=virtualbox`.
+
 For Windows:
 
 ```


### PR DESCRIPTION
Upon installing VirtualBox (or upgrading virtual box) there was a very slight hint to restart by prompting a user to go to preferences to check it out. It wasn't until running
```
minikube start --mount=True --mount-string="/var/tmp:/var/tmp" --vm-driver=virtualbox 
```

that the bug showed. It wasn't until I found [this comment on the issue](https://github.com/kubernetes/minikube/issues/2439#issuecomment-381334620) that it spurred me to dig in and finalize the restart. After re-creating minikube on virutalbox all is well.