### PR TITLE
Add supported Python version

### DIFF
--- a/course1/week1-ungraded-lab/README.md
+++ b/course1/week1-ungraded-lab/README.md
@@ -42,7 +42,7 @@ Type `ls` and let's take a quick look at the content inside `week1-ungraded-lab`
  
 ### Prerequisites: Have [conda](https://docs.conda.io/en/latest/) installed on your local machine.
  
-You will use Conda as an environment management system so that all the dependencies you need for this ungraded lab are stored in an isolated environment.
+You will use Conda as an environment management system so that all the dependencies you need for this ungraded lab are stored in an isolated environment. Make sure you have Python 3.6.x, 3.7.x or 3.8.x version installed, because some of the dependencies are not supporting latest version of Python.
  
 Conda includes a lot of libraries so if you are only installing it to complete this lab , we suggest using [miniconda](https://docs.conda.io/en/latest/miniconda.html), which is a minimal version of conda.
  


### PR DESCRIPTION
This PR adds the supported version of Python to the `week1 lab`.
Conda by default has Python 3.9 version supported. Using that version `pip install -r requirements` will fail because of `numpy`. Check the error log below:

```
  × pip subprocess to install build dependencies did not run successfully.
  │ exit code: 1
  ╰─> [330 lines of output]
      Ignoring numpy: markers 'python_version == "3.6" and platform_machine != "aarch64" and platform_machine != "arm64"' don't match your environment
      Ignoring numpy: markers 'python_version >= "3.6" and sys_platform == "linux" and platform_machine == "aarch64"' don't match your environment
      Ignoring numpy: markers 'python_version >= "3.6" and sys_platform == "darwin" and platform_machine == "arm64"' don't match your environment
      Ignoring numpy: markers 'python_version == "3.7" and platform_machine != "aarch64" and platform_machine != "arm64"' don't match your environment
      Ignoring numpy: markers 'python_version == "3.8" and platform_machine != "aarch64" and platform_machine != "arm64"' don't match your environment
```