### PR TITLE
Fix runner issue for C4_W3_Lab_4

### DIFF
--- a/.github/workflows/course4-week3-lab.yml
+++ b/.github/workflows/course4-week3-lab.yml
@@ -14,7 +14,7 @@ jobs:
   # This workflow contains a single job called "test"
   test:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         # Use bash as the shell
@@ -31,7 +31,7 @@ jobs:
         name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7.8'
+          python-version: '3.7.7'
       - 
         name: Install dependencies
         run: |

--- a/.github/workflows/course4-week3-lab.yml
+++ b/.github/workflows/course4-week3-lab.yml
@@ -31,7 +31,7 @@ jobs:
         name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7.7'
+          python-version: '3.7.8'
       - 
         name: Install dependencies
         run: |

--- a/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
+++ b/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
@@ -4,7 +4,7 @@ from typing import List
 from fastapi import FastAPI
 from pydantic import BaseModel, conlist
 
-
+# Initial commit
 
 app = FastAPI(title="Predicting Wine Class with batching")
 

--- a/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
+++ b/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
@@ -4,7 +4,7 @@ from typing import List
 from fastapi import FastAPI
 from pydantic import BaseModel, conlist
 
-# Initial Commit
+
 
 app = FastAPI(title="Predicting Wine Class with batching")
 

--- a/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
+++ b/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
@@ -4,7 +4,7 @@ from typing import List
 from fastapi import FastAPI
 from pydantic import BaseModel, conlist
 
-
+# Initial Commit
 
 app = FastAPI(title="Predicting Wine Class with batching")
 

--- a/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
+++ b/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
@@ -4,7 +4,7 @@ from typing import List
 from fastapi import FastAPI
 from pydantic import BaseModel, conlist
 
-# Initial commit
+
 
 app = FastAPI(title="Predicting Wine Class with batching")
 


### PR DESCRIPTION
There is an issue when using GitHub actions during first push which is:
" Version 3.7.7 (python version) with arch x64 not found"

The reason is that for runner Ubuntu-latest, no such support exists.

This commit locks the runner to a fixed version of Ubuntu (20.04), permanently fixing the issue stated above.