### PR TITLE
 Avoid Node.js 12 actions deprecation warning + Supported Python version

### DIFF
--- a/.github/workflows/course4-week3-lab.yml
+++ b/.github/workflows/course4-week3-lab.yml
@@ -31,7 +31,7 @@ jobs:
         name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.x'
+          python-version: '3.7.7'
       - 
         name: Install dependencies
         run: |

--- a/.github/workflows/course4-week3-lab.yml
+++ b/.github/workflows/course4-week3-lab.yml
@@ -26,10 +26,10 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - 
         name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.12.0'
       - 

--- a/.github/workflows/course4-week3-lab.yml
+++ b/.github/workflows/course4-week3-lab.yml
@@ -31,7 +31,7 @@ jobs:
         name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.12.0'
+          python-version: '3.x'
       - 
         name: Install dependencies
         run: |

--- a/.github/workflows/course4-week3-lab.yml
+++ b/.github/workflows/course4-week3-lab.yml
@@ -31,7 +31,7 @@ jobs:
         name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10.0'
+          python-version: '3.12.0'
       - 
         name: Install dependencies
         run: |

--- a/.github/workflows/course4-week3-lab.yml
+++ b/.github/workflows/course4-week3-lab.yml
@@ -31,7 +31,7 @@ jobs:
         name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.7.7'
+          python-version: '3.x'
       - 
         name: Install dependencies
         run: |

--- a/.github/workflows/course4-week3-lab.yml
+++ b/.github/workflows/course4-week3-lab.yml
@@ -31,7 +31,7 @@ jobs:
         name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7.7'
+          python-version: '3.10.0'
       - 
         name: Install dependencies
         run: |

--- a/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
+++ b/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, conlist
 app = FastAPI(title="Predicting Wine Class with batching")
 
 # Open classifier in global scope
-with open("models/wine-95.pkl", "rb") as file:
+with open("models/wine-95-fixed.pkl", "rb") as file:
     clf = pickle.load(file)
 
 

--- a/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
+++ b/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, conlist
 app = FastAPI(title="Predicting Wine Class with batching")
 
 # Open classifier in global scope
-with open("models/wine.pkl", "rb") as file:
+with open("models/wine-95.pkl", "rb") as file:
     clf = pickle.load(file)
 
 

--- a/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
+++ b/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel, conlist
 
 """
-Checking GitHub Actions 
+GitHub Actions 
 """
 
 app = FastAPI(title="Predicting Wine Class with batching")

--- a/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
+++ b/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel, conlist
 
 """
-Getting familiar with GitHub Actions 
+Checking GitHub Actions 
 """
 
 app = FastAPI(title="Predicting Wine Class with batching")

--- a/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
+++ b/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
@@ -4,7 +4,9 @@ from typing import List
 from fastapi import FastAPI
 from pydantic import BaseModel, conlist
 
-
+"""
+Getting familiar with GitHub Actions 
+"""
 
 app = FastAPI(title="Predicting Wine Class with batching")
 

--- a/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
+++ b/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel, conlist
 
 """
-GitHub Actions 
+Getting familiar with GitHub Actions 
 """
 
 app = FastAPI(title="Predicting Wine Class with batching")

--- a/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
+++ b/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel, conlist
 
 """
-Getting familiar with GitHub Actions 
+GitHub Actions 
 """
 
 app = FastAPI(title="Predicting Wine Class with batching")

--- a/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
+++ b/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
@@ -4,9 +4,7 @@ from typing import List
 from fastapi import FastAPI
 from pydantic import BaseModel, conlist
 
-"""
-GitHub Actions 
-"""
+
 
 app = FastAPI(title="Predicting Wine Class with batching")
 

--- a/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/test_clf.py
+++ b/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/test_clf.py
@@ -1,6 +1,9 @@
 import pickle
 from main import clf
 
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
 
 def test_accuracy():
 
@@ -16,3 +19,16 @@ def test_accuracy():
 
     # Accuracy should be over 90%
     assert acc > 0.9
+
+
+def test_pipeline_and_scaler():
+
+    # Check if clf is an instance of sklearn.pipeline.Pipeline 
+    isPipeline = isinstance(clf, Pipeline)
+    assert isPipeline
+    
+    if isPipeline:
+        # Check if first step of pipeline is an instance of 
+        # sklearn.preprocessing.StandardScaler
+        firstStep = [v for v in clf.named_steps.values()][0]
+        assert isinstance(firstStep, StandardScaler)


### PR DESCRIPTION
When running the **CI/CD pipeline** with **GH Actions** to automate unit tests. I got a warning telling me that `Node.js 12 actions deprecation`. Also, another error that did not allow the test to pass was the **Python version** `3.7.7`.

1. Consider modifying the following lines in the file `course4-week3-lab.yml`. (3 lines)
```
    steps:
      -
        name: Checkout
        uses: actions/checkout@v2
      - 
        name: Set up Python
        uses: actions/setup-python@v2
        with:
          python-version: '3.7.7'
```

2. The test will pass using these lines instead

```
    steps:
      -
        name: Checkout
        uses: actions/checkout@v3
      - 
        name: Set up Python
        uses: actions/setup-python@v3
        with:
          python-version: '3.x'
```