### PR TITLE
Fix (C1W2): Adding Check for Existing Directory Before Creation

### DIFF
--- a/course1/week2-ungraded-lab/C1W2_Ungraded_Lab_Birds_Cats_Dogs.ipynb
+++ b/course1/week2-ungraded-lab/C1W2_Ungraded_Lab_Birds_Cats_Dogs.ipynb
@@ -227,7 +227,8 @@
    "source": [
     "raw_birds_dir = '/tmp/data/CUB_200_2011/images'\n",
     "base_birds_dir = os.path.join(base_dir,'PetImages/Bird')\n",
-    "os.mkdir(base_birds_dir)\n",
+    "if not os.path.exists(base_birds_dir):\n",
+    "  os.mkdir(base_birds_dir)\n",
     "\n",
     "for subdir in os.listdir(raw_birds_dir):\n",
     "  subdir_path = os.path.join(raw_birds_dir, subdir)\n",


### PR DESCRIPTION
This pull request addresses an issue found in the `C1W2_Ungraded_Lab_Birds_Cats_Dogs.ipynb` file located at `course1/week2-ungraded-lab`. The problem was related to the creation of a directory without checking whether it already exists. To ensure a smoother user experience and prevent potential errors, I have made the following change:

**Original Code:**
```python
os.mkdir(base_birds_dir)
```

**Modified Code:**
```python
if not os.path.exists(base_birds_dir):
    os.mkdir(base_birds_dir)
```

This change adds a condition to check if the directory exists before attempting to create it. If the directory already exists, no action is taken, avoiding any unintended overwrites or errors.

Thank you for considering this pull request. I look forward to your feedback and suggestions for improvement.