### PR TITLE
Fix naming of parameters in conlist type function from pydantic

### DIFF
--- a/course4/week2-ungraded-labs/C4_W2_Lab_1_FastAPI_Docker/with-batch/app/main.py
+++ b/course4/week2-ungraded-labs/C4_W2_Lab_1_FastAPI_Docker/with-batch/app/main.py
@@ -9,7 +9,7 @@ app = FastAPI(title="Predicting Wine Class with batching")
 
 # Represents a batch of wines
 class Wine(BaseModel):
-    batches: List[conlist(item_type=float, min_items=13, max_items=13)]
+    batches: List[conlist(item_type=float, min_length=13, max_length=13)]
 
 
 @app.on_event("startup")

--- a/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
+++ b/course4/week3-ungraded-labs/C4_W3_Lab_4_Github_Actions/app/main.py
@@ -15,7 +15,7 @@ with open("models/wine.pkl", "rb") as file:
 
 class Wine(BaseModel):
     batches: List[conlist(item_type=float, min_length=13, max_length=13)]
-
+#
 
 @app.post("/predict")
 def predict(wine: Wine):


### PR DESCRIPTION
This pull request addresses an issue found in the `main.py` file located at `/course4/week2-ungraded-labs/C4_W2_Lab_1_FastAPI_Docker/with-batch/app`. 

The problem was due to applying the `conlist` type function from Pydantic with the wrong naming of two keyword arguments. The two keyword arguments were incorrectly named `min_items` and `max_items` but the correct names are respectively `min_length` and `max_length`.